### PR TITLE
panic: runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/transport/router.go
+++ b/transport/router.go
@@ -41,6 +41,7 @@ func (self *Router) Handle(cb Callback, filters ...Filter) Handler {
 }
 
 func (self *Router) CloseHandle(filter Filter, el *list.Element) {
+	self.init()
 	self.cbLock.Lock()
 	var eMap = self.cbMap[filter]
 	if eMap != nil {


### PR DESCRIPTION
[signal 0xb code=0x1 addr=0x28 pc=0xb85c57]
goroutine 2880459218 [running]:
panic(0x12ec8c0, 0xc8200100c0)
/go/src/go/src/runtime/panic.go:464 +0x3e6
vendor/github.com/zenhotels/astranet/transport.(*Router).CloseHandle(0xccfe9441a0, 0xd1a5f24004, 0x20ebba3fe676deb1, 0x3419, 0x4e189e6d8069f71c, 0x13acf53, 0xd1a5f240c0)
/go/src/build/src/vendor/github.com/zenhotels/astranet/transport/router.go:49 +0x167
vendor/github.com/zenhotels/astranet/transport.(*handler).Close(0xce23740fe0)
/go/src/build/src/vendor/github.com/zenhotels/astranet/transport/upstream.go:489 +0xeb
vendor/github.com/zenhotels/astranet/socket.(*stream).Close.func1()
/go/src/build/src/vendor/github.com/zenhotels/astranet/socket/stream.go:214 +0xdc
created by time.goFunc
/go/src/go/src/time/sleep.go:129 +0x3a

Nil pointer deref fixed.